### PR TITLE
Update buy now button with correct link

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -24,7 +24,7 @@ const Header = props => (
             disabilities and is one of the longest living ventilator dependent
             c1 quadriplegics in the United States. This is his story.
           </p>
-          <a href="https://www.amazon.com/Snow-Skis-Wheelchair-Quadriplegia-Failed/dp/108279838X">
+          <a href="https://www.amazon.com/Snow-Skiis-Wheelchair-Quadriplegia-Failed/dp/1090608683">
             <button>BUY AT AMAZON</button>
           </a>
         </div>


### PR DESCRIPTION
Turns out that the old link was for the first amazon post, which only had the paperback option without any reviews!

The correct link goes to the second amazon posting that have both kindle and paperback option along with reviews. It have skid misspelt as skii, though. 

When Mark tried to fix the misspell in the correct link, the guy he was using... Amazon or whatever, they just made a new amazon post instead of fixing the old post! 